### PR TITLE
Allow selectors to be provided in any order

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     ]
   },
   "dependencies": {
+    "lodash.flattendeep": "^4.4.0",
     "nearley": "^2.7.10"
   },
   "description": "A CSS selector parser.",

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -1,15 +1,11 @@
 @{%
+  const flattenDeep = require('lodash.flattendeep');
   const appendItem = (a, b) => d => d[a].concat([d[b]]);
   const appendItemChar = (a, b) => d => d[a].concat(d[b]);
 
   const flatten = d => {
     d = d.filter((r) => { return r !== null; });
-    return d.reduce(
-      (a, b) => {
-        return a.concat(b);
-      },
-      []
-    );
+    return flattenDeep(d);
   };
 
   const combinatorMap = {
@@ -37,8 +33,16 @@ combinator ->
 selector -> selectorBody {% d => ({type: 'selector', body: d[0]}) %}
 
 selectorBody ->
-    typeSelector:? idSelector:? classSelector:* attributeValueSelector:* attributePresenceSelector:* pseudoClassSelector:* pseudoElementSelector:? {% (d, i, reject) => { const selectors = flatten(d); if (!selectors.length) return reject; return selectors; } %}
-  | universalSelector idSelector:? classSelector:* attributeValueSelector:* attributePresenceSelector:* pseudoClassSelector:* pseudoElementSelector:? {% flatten %}
+    typeSelector:? simpleSelector:* {% (d, i, reject) => { const selectors = flatten(d); if (!selectors.length) return reject; return selectors; } %}
+  | universalSelector simpleSelector:* {% flatten %}
+
+simpleSelector ->
+  idSelector
+| classSelector
+| attributeValueSelector
+| attributePresenceSelector
+| pseudoClassSelector
+| pseudoElementSelector
 
 typeSelector -> attributeName {% d => ({type: 'typeSelector', name: d[0]}) %}
 

--- a/test/sequences.js
+++ b/test/sequences.js
@@ -187,7 +187,10 @@ for (const [selector, expectedResult] of Object.entries(validSelectors)) {
 }
 
 const invalidSelectors = [
-  '#bar0#bar1'
+  '##bar0#bar1',
+  'div.foo[bar',
+  'foo..bar',
+  '[[bar]]'
 ];
 
 for (const invalidSelector of invalidSelectors) {


### PR DESCRIPTION
Fixes #6 

It may not make a lot of sense to use selectors like `.foo#bar` but they're valid according to the CSS3 grammar. This PR implements the `simpleSelector` nonterminal so that `selectorBody` can allow any selector in any order.

It also removes `#bar0#bar1` from the `invalidSelector` list and adds a few other invalid selectors because `#bar0#bar1` is _technically_ a valid CSS selector (`document.querySelector('#bar0#bar1')` does not throw a parse error, for example)

cc @gajus 